### PR TITLE
Tables may already exist on repeated tests

### DIFF
--- a/modules/doobie/src/test/scala/io/chrisdavenport/fuuid/doobie/postgres/PostgresInstanceSpec.scala
+++ b/modules/doobie/src/test/scala/io/chrisdavenport/fuuid/doobie/postgres/PostgresInstanceSpec.scala
@@ -20,7 +20,7 @@ class PostgresInstanceSpec extends mutable.Specification with IOChecker with Bef
 
   def beforeAll(): Unit = {
     sql"""
-    CREATE TABLE PostgresInstanceSpec (
+    CREATE TABLE IF NOT EXISTS PostgresInstanceSpec (
       id   UUID NOT NULL
     )
     """.update.run.transact(transactor).void.unsafeRunSync()

--- a/modules/doobie/src/test/scala/io/chrisdavenport/fuuid/doobie/postgres/PostgresTraversalSpec.scala
+++ b/modules/doobie/src/test/scala/io/chrisdavenport/fuuid/doobie/postgres/PostgresTraversalSpec.scala
@@ -20,7 +20,7 @@ class PostgresTraversalSpec extends mutable.Specification
 
   def beforeAll(): Unit = {
     sql"""
-    CREATE TABLE PostgresTraversalSpec (
+    CREATE TABLE IF NOT EXISTS PostgresTraversalSpec (
       id   UUID NOT NULL
     )
     """.update.run.transact(transactor).void.unsafeRunSync()


### PR DESCRIPTION
Locally if running tests more than once this will error. Problematic when running testing both versions simultaneously. This fixes that error.