### PR TITLE
Avoid `wartremover.warts.Throw` error when using FUUID literal

### DIFF
--- a/modules/core/src/main/scala/io/chrisdavenport/fuuid/FUUID.scala
+++ b/modules/core/src/main/scala/io/chrisdavenport/fuuid/FUUID.scala
@@ -60,8 +60,11 @@ object FUUID {
             fromString(s)
             .fold(
               e => c.abort(c.enclosingPosition, e.getMessage.replace("UUID", "FUUID")),
-              _ =>
-                q"_root_.io.chrisdavenport.fuuid.FUUID.fromString($s).fold(throw _, _root_.scala.Predef.identity)"
+              _ => q"""
+                @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+                val fuuid = _root_.io.chrisdavenport.fuuid.FUUID.fromString($s).fold(throw _, _root_.scala.Predef.identity)
+                fuuid
+              """
             )
         case _ =>
           c.abort(


### PR DESCRIPTION
What has been done in this PR?

- Suppress false positive inside macro to avoid users encountering it

For example, if an user, working on a project with wartremover on writes the following code...

```scala
val fuuid = FUUID.fuuid("86c57a6d-39fe-44fe-ad01-6c77699b9f03")
```

...compiler will fail with:

```
[error] ../.../../Whatever.scala:42:42: [wartremover:Throw] throw is disabled
[error]         FUUID.fuuid("86c57a6d-39fe-44fe-ad01-6c77699b9f03")
[error]                ^
[error] one error found
```
