### PR TITLE
Add Constant For Nil UUID

### DIFF
--- a/modules/core/src/main/scala/io/chrisdavenport/fuuid/FUUID.scala
+++ b/modules/core/src/main/scala/io/chrisdavenport/fuuid/FUUID.scala
@@ -98,7 +98,7 @@ object FUUID {
   /**
     * The Nil UUID.
     *
-    * This is a the constant UUID for which all bits are 0.
+    * This is a constant UUID for which all bits are 0.
     *
     * @see [[https://tools.ietf.org/html/rfc4122#section-4.1.7]]
     */

--- a/modules/core/src/main/scala/io/chrisdavenport/fuuid/FUUID.scala
+++ b/modules/core/src/main/scala/io/chrisdavenport/fuuid/FUUID.scala
@@ -38,7 +38,7 @@ object FUUID {
   def fromString(s: String): Either[Throwable, FUUID] =
     Either.catchNonFatal(new FUUID(UUID.fromString(s)))
 
-  def fromStringOpt(s: String): Option[FUUID] = 
+  def fromStringOpt(s: String): Option[FUUID] =
     fromString(s).toOption
 
   def fromStringF[F[_]](s: String)(implicit AE: ApplicativeError[F, Throwable]): F[FUUID] =
@@ -77,7 +77,7 @@ object FUUID {
   /**
     * Creates a new name-based UUIDv5.
     * NOTE: Not implemented for Scala.js!
-    **/ 
+    **/
   def nameBased[F[_]](namespace: FUUID, name: String)(implicit AE: ApplicativeError[F, Throwable]): F[FUUID] =
     PlatformSpecificMethods.nameBased[F](namespace, name, AE)
 
@@ -95,4 +95,13 @@ object FUUID {
     def withUUID[A](fuuid: FUUID)(f: UUID => A): A = f(fuuid.uuid)
   }
 
+  /**
+    * The Nil UUID.
+    *
+    * This is a the constant UUID for which all bits are 0.
+    *
+    * @see [[https://tools.ietf.org/html/rfc4122#section-4.1.7]]
+    */
+  val NilUUID: FUUID =
+    FUUID.fromUUID(new UUID(0L, 0L))
 }


### PR DESCRIPTION
As defined by RFC 4122, this UUID is the UUID with all bits set to 0. Pragmatically, it is a useful UUID to use in instances where one requires a known UUID value, but would prefer not to generate one. This use case often arises in testing, but it is not limited to that scope.